### PR TITLE
Swift Package Manager Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,9 +10,6 @@ let package = Package(
             name: "WeavrComponents",
             targets: ["WeavrComponents"])
     ],
-    dependencies: [
-        .package(url: "https://github.com/SumSubstance/IdensicMobileSDK-iOS.git", .upToNextMajor(from: "1.28.0")),
-    ],
     targets: [
         .binaryTarget(
             name: "WeavrComponents",

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "WeavrComponents",
+    products: [
+        .library(
+            name: "WeavrComponents",
+            targets: ["WeavrComponents"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/SumSubstance/IdensicMobileSDK-iOS.git", .upToNextMajor(from: "1.28.0")),
+    ],
+    targets: [
+        .binaryTarget(
+            name: "WeavrComponents",
+            path: "WeavrComponents.xcframework"
+        )
+    ]
+)


### PR DESCRIPTION
### Description
Adds Swift Package Manager support to the repository.

### Rationale
Many modern projects use Swift Package Manager now instead of things like CocoaPods and Carthage. Swift Package Manager is lightweight and in-built to Xcode so is favoured by many. 

### Changes
Adding a `package.swift` file is generally sufficient to support this and that's what this PR contains. The package references the local `xcframework` in the repository so requires no further changes from Weavr on that front.

**One additional change is required by the weavr developers.** The current `xcframework` in the repository has been distributed using the outdated `Apple Swift version 5.7.2 Compiler`. The current compiler is `Apple Swift version 5.9 Compiler`. Attempting to use the `xcframework` in a new project produces compiler errors as the package is outdated. This can be fixed by simply enabling the `Build Libraries for Distribution` setting in the Xcode project for the `WeavrComponents` project and exporting a new `xcframework`. This should enable the xcframework to remain compatible across multiple Swift toolchain version.

Tagging @stephen-galea-weavr here in the hope you are able to action the above for me.

Once the above is done I will merge the upstream and re-test in our project before finalising this PR.

